### PR TITLE
service waiting logic

### DIFF
--- a/docker_services_cli/docker-services.yml
+++ b/docker_services_cli/docker-services.yml
@@ -39,17 +39,6 @@ services:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - discovery.type=single-node
-    healthcheck:
-      test:
-        [
-          "CMD",
-          "curl",
-          "-f",
-          "localhost:9200/_cluster/health?wait_for_status=green",
-        ]
-      interval: 30s
-      timeout: 30s
-      retries: 5
     ulimits:
       memlock:
         soft: -1

--- a/docker_services_cli/services.py
+++ b/docker_services_cli/services.py
@@ -8,8 +8,139 @@
 """Services module."""
 
 import subprocess
+import time
 
-from .config import DOCKER_SERVICES_FILEPATH
+import click
+
+from .config import DOCKER_SERVICES_FILEPATH, MYSQL, POSTGRESQL
+
+
+def _run_healthcheck_command(command):
+    """Runs a given command, returns True if it succeeds, False otherwise."""
+    try:
+        subprocess.check_call(
+            command,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL
+        )
+        return True
+    except subprocess.CalledProcessError:
+        return False
+
+
+def es_healthcheck(*args, **kwargs):
+    """Elasticsearch healthcheck."""
+    return _run_healthcheck_command([
+        "curl",
+        "-f",
+        "localhost:9200/_cluster/health?wait_for_status=green"
+    ])
+
+
+def postgresql_healthcheck(*args, **kwargs):
+    """Postgresql healthcheck."""
+    filepath = kwargs['filepath']
+
+    return _run_healthcheck_command([
+        "docker-compose",
+        "--file",
+        filepath,
+        "exec",
+        "postgresql",
+        "bash",
+        "-c",
+        "pg_isready",
+    ])
+
+
+def mysql_healthcheck(*args, **kwargs):
+    """Mysql healthcheck."""
+    filepath = kwargs['filepath']
+    password = MYSQL["MYSQL_ROOT_PASSWORD"]
+
+    return _run_healthcheck_command([
+        "docker-compose",
+        "--file",
+        filepath,
+        "exec",
+        "mysql",
+        "bash",
+        "-c",
+        f"mysql -p{password} -e \"select Version();\"",
+    ])
+
+
+def redis_healthcheck(*args, **kwargs):
+    """Redis healthcheck."""
+    filepath = kwargs['filepath']
+
+    return _run_healthcheck_command([
+        "docker-compose",
+        "--file",
+        filepath,
+        "exec",
+        "redis",
+        "bash",
+        "-c",
+        "redis-cli ping",
+        "|",
+        "grep 'PONG'",
+        "&>/dev/null;",
+    ])
+
+
+READYNESS_CHECKS = {
+    "es": es_healthcheck,
+    "postgresql": postgresql_healthcheck,
+    "mysql": mysql_healthcheck,
+    "redis": redis_healthcheck,
+}
+"""Readyness check functions module path, as string."""
+
+
+def wait_for_services(services, filepath=DOCKER_SERVICES_FILEPATH, max_retries=6):
+    """Wait for services to be up.
+
+    It performs configured healthchecks in a serial fashion, following the
+    order given in the ``up`` command.
+    """
+    for service in services:
+        exp_backoff_time = 2
+        try_ = 1
+        # Using plain __import__ to avoid depending on invenio-base
+        check = READYNESS_CHECKS[service]
+        ready = check(filepath=filepath)
+        while not ready and try_ < max_retries:
+            click.secho(
+                f"{service} not ready at {try_} retries, waiting " \
+                f"{exp_backoff_time}s",
+                fg="yellow"
+            )
+            try_ += 1
+            time.sleep(exp_backoff_time)
+            exp_backoff_time *= 2
+            ready = check(filepath=filepath)
+
+        if not ready:
+            click.secho(f"Unable to boot up {service}", fg="red")
+            exit(1)
+        else:
+            click.secho(f"{service} up and running!", fg="green")
+
+
+def services_up(services, filepath=DOCKER_SERVICES_FILEPATH, wait=True):
+    """Start the given services up.
+
+    docker-compose is smart about not rebuilding an image if
+    there is no need to, so --build is not a slow default. In addition
+    ``--detach`` is not supported in 1.17.0 or previous.
+    """
+    command = ["docker-compose", "--file", filepath, "up", "-d"]
+    command.extend(services)
+
+    subprocess.check_call(command)
+    if wait:
+        wait_for_services(services, filepath)
 
 
 def services_down(filepath=DOCKER_SERVICES_FILEPATH):
@@ -20,18 +151,4 @@ def services_down(filepath=DOCKER_SERVICES_FILEPATH):
     """
     command = ["docker-compose", "--file", filepath, "down"]
 
-    subprocess.run(command, check=True)
-
-
-def services_up(services, filepath=DOCKER_SERVICES_FILEPATH):
-    """Start the given services up.
-
-    docker-compose is smart about not rebuilding an image if
-    there is no need to, so --build is not a slow default. In addition
-    ``--detach`` is not supported in 1.17.0 or previous.
-    """
-    command = ["docker-compose", "--file", filepath, "up", "-d"]
-
-    command.extend(services)
-
-    subprocess.run(command, check=True)
+    subprocess.check_call(command)


### PR DESCRIPTION
Example execution with ES7 (slowest):
```bash
$ docker-services-cli up  es postgresql redis mysql
Creating network "docker_services_cli_default" with the default driver
Creating docker_services_cli_redis_1      ... done
Creating docker_services_cli_es_1         ... done
Creating docker_services_cli_mysql_1      ... done
Creating docker_services_cli_postgresql_1 ... done
es not ready at 1 retries, waiting 2s
es not ready at 2 retries, waiting 4s
es not ready at 3 retries, waiting 8s
es up and running!
postgresql up and running!
redis up and running!
mysql up and running!
Services up!
```