### PR TITLE
gh: release to pypi through gh-actions

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,26 @@
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  build-n-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel
+      - name: Build package
+        run: |
+          python setup.py sdist bdist_wheel
+      - name: pypi-publish
+        uses: pypa/gh-action-pypi-publish@v1.3.1
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@
 # Docker-Services-CLI is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
 
+# blocklist
+branches:
+  except:
+    - /^v\d+\.\d+(\.\d+)?(\S*)?$/
+
 notifications:
   email: false
 
@@ -47,14 +52,3 @@ script:
 
 after_success:
   - coveralls
-
-deploy:
-  provider: pypi
-  user: inveniosoftware
-  password:
-    secure: PYPI_SECRET
-  distributions: "sdist bdist_wheel"
-  on:
-    tags: true
-    repo: inveniosoftware/docker-services-cli
-  skip_existing: true

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ include *.rst
 include *.sh
 include *.txt
 include LICENSE
+recursive-include .github/workflows *.yml
 recursive-include docs *.bat
 recursive-include docs *.py
 recursive-include docs *.rst


### PR DESCRIPTION
Migrated according to <https://codimd.web.cern.ch/_wtkZy6MR5ad69HQeERJaA>