### PR TITLE
services: support verbose mode on healthchecks

### DIFF
--- a/docker_services_cli/version.py
+++ b/docker_services_cli/version.py
@@ -11,4 +11,4 @@ This file is imported by ``docker_services_cli.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
**NOTE**
I know the passing of kwargs is not optimal (it sort of breaks the purpose when passing-extracting). A bigger refactor can be made later. This change is blocking debugging the gh actions.