### PR TITLE
support verbose and no TTY on docker-compose

### DIFF
--- a/docker_services_cli/services.py
+++ b/docker_services_cli/services.py
@@ -7,7 +7,8 @@
 
 """Services module."""
 
-import subprocess
+from os import path
+from subprocess import check_call, Popen, PIPE
 import time
 
 import click
@@ -15,47 +16,58 @@ import click
 from .config import DOCKER_SERVICES_FILEPATH, MYSQL, POSTGRESQL
 
 
-def _run_healthcheck_command(command):
+def _run_healthcheck_command(command, verbose=False):
     """Runs a given command, returns True if it succeeds, False otherwise."""
-    try:
-        subprocess.check_call(
-            command,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL
-        )
+    p = Popen(command, stdout=PIPE, stderr=PIPE)
+    output, error = p.communicate()
+    output = output.decode("utf-8")
+    error = error.decode("utf-8")
+    if p.returncode == 0:
+        if verbose:
+            click.secho(output, fg="green")
         return True
-    except subprocess.CalledProcessError:
+    if p.returncode != 0:
+        if verbose:
+            click.secho(
+                f"Healthcheck failed.\nOutput: {output}\nError:{error}",
+                fg="red"
+            )
         return False
 
 
 def es_healthcheck(*args, **kwargs):
     """Elasticsearch healthcheck."""
+    verbose = kwargs['verbose']
+
     return _run_healthcheck_command([
         "curl",
         "-f",
         "localhost:9200/_cluster/health?wait_for_status=green"
-    ])
+    ], verbose)
 
 
 def postgresql_healthcheck(*args, **kwargs):
     """Postgresql healthcheck."""
     filepath = kwargs['filepath']
+    verbose = kwargs['verbose']
 
     return _run_healthcheck_command([
         "docker-compose",
         "--file",
         filepath,
         "exec",
+        "-T",
         "postgresql",
         "bash",
         "-c",
         "pg_isready",
-    ])
+    ], verbose)
 
 
 def mysql_healthcheck(*args, **kwargs):
     """Mysql healthcheck."""
     filepath = kwargs['filepath']
+    verbose = kwargs['verbose']
     password = MYSQL["MYSQL_ROOT_PASSWORD"]
 
     return _run_healthcheck_command([
@@ -63,22 +75,25 @@ def mysql_healthcheck(*args, **kwargs):
         "--file",
         filepath,
         "exec",
+        "-T",
         "mysql",
         "bash",
         "-c",
         f"mysql -p{password} -e \"select Version();\"",
-    ])
+    ], verbose)
 
 
 def redis_healthcheck(*args, **kwargs):
     """Redis healthcheck."""
     filepath = kwargs['filepath']
+    verbose = kwargs['verbose']
 
     return _run_healthcheck_command([
         "docker-compose",
         "--file",
         filepath,
         "exec",
+        "-T",
         "redis",
         "bash",
         "-c",
@@ -86,7 +101,7 @@ def redis_healthcheck(*args, **kwargs):
         "|",
         "grep 'PONG'",
         "&>/dev/null;",
-    ])
+    ], verbose)
 
 
 HEALTHCHECKS = {
@@ -98,7 +113,8 @@ HEALTHCHECKS = {
 """Health check functions module path, as string."""
 
 
-def wait_for_services(services, filepath=DOCKER_SERVICES_FILEPATH, max_retries=6):
+def wait_for_services(services, filepath=DOCKER_SERVICES_FILEPATH,
+                      max_retries=6, verbose=False):
     """Wait for services to be up.
 
     It performs configured healthchecks in a serial fashion, following the
@@ -114,7 +130,7 @@ def wait_for_services(services, filepath=DOCKER_SERVICES_FILEPATH, max_retries=6
         try_ = 1
         # Using plain __import__ to avoid depending on invenio-base
         check = HEALTHCHECKS[service]
-        ready = check(filepath=filepath)
+        ready = check(filepath=filepath, verbose=verbose)
         while not ready and try_ < max_retries:
             click.secho(
                 f"{service} not ready at {try_} retries, waiting " \
@@ -124,7 +140,7 @@ def wait_for_services(services, filepath=DOCKER_SERVICES_FILEPATH, max_retries=6
             try_ += 1
             time.sleep(exp_backoff_time)
             exp_backoff_time *= 2
-            ready = check(filepath=filepath)
+            ready = check(filepath=filepath, verbose=verbose)
 
         if not ready:
             click.secho(f"Unable to boot up {service}", fg="red")
@@ -133,19 +149,25 @@ def wait_for_services(services, filepath=DOCKER_SERVICES_FILEPATH, max_retries=6
             click.secho(f"{service} up and running!", fg="green")
 
 
-def services_up(services, filepath=DOCKER_SERVICES_FILEPATH, wait=True):
+def services_up(services, filepath=DOCKER_SERVICES_FILEPATH, wait=True,
+                retries=6, verbose=False):
     """Start the given services up.
 
     docker-compose is smart about not rebuilding an image if
     there is no need to, so --build is not a slow default. In addition
     ``--detach`` is not supported in 1.17.0 or previous.
     """
+    if not path.exists(filepath):
+        click.secho(f"Filepaht {filepath} for docker-services.yml file does not exist.", fg="red")
+        exit(1)
+
     command = ["docker-compose", "--file", filepath, "up", "-d"]
     command.extend(services)
 
-    subprocess.check_call(command)
+    check_call(command)
     if wait:
-        wait_for_services(services, filepath)
+        wait_for_services(services, filepath, max_retries=retries,
+                          verbose=verbose)
 
 
 def services_down(filepath=DOCKER_SERVICES_FILEPATH):
@@ -156,4 +178,4 @@ def services_down(filepath=DOCKER_SERVICES_FILEPATH):
     """
     command = ["docker-compose", "--file", filepath, "down"]
 
-    subprocess.check_call(command)
+    check_call(command)

--- a/docker_services_cli/version.py
+++ b/docker_services_cli/version.py
@@ -11,4 +11,4 @@ This file is imported by ``docker_services_cli.__init__``,
 and parsed by ``setup.py``.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"


### PR DESCRIPTION
**NOTE**
I know the passing of kwargs is not optimal (it sort of breaks the purpose when passing-extracting). A bigger refactor can be made later. This change is blocking debugging the gh actions.

Adding the `-T` option to the `exec` helps avoiding https://github.com/docker/compose/issues/7306 when running on GH actions.

e.g.:
![Screenshot 2020-10-28 at 13 39 19](https://user-images.githubusercontent.com/6756943/97436983-20d03d80-1923-11eb-9daa-9b945efe31eb.png)
