### PR TITLE
global: removes "restart" from services

### DIFF
--- a/docker_services_cli/docker-services.yml
+++ b/docker_services_cli/docker-services.yml
@@ -9,13 +9,11 @@ version: "2.3"
 services:
   redis:
     image: redis
-    restart: "always"
     read_only: true
     ports:
       - "6379:6379"
   mysql:
     image: mysql:${MYSQL_VERSION}
-    restart: "always"
     environment:
       - "MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}"
       - "MYSQL_DATABASE=${MYSQL_DB}"
@@ -25,7 +23,6 @@ services:
       - "3306:3306"
   postgresql:
     image: postgres:${POSTGRESQL_VERSION}
-    restart: "always"
     environment:
       - "POSTGRES_USER=${POSTGRESQL_USER}"
       - "POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}"
@@ -34,7 +31,6 @@ services:
       - "5432:5432"
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ES_VERSION}
-    restart: "always"
     environment:
       - bootstrap.memory_lock=true
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"


### PR DESCRIPTION
This is basically to avoid the following scenario:

1. Run `docker-services-cli up ...` which bring up containers
2. Finish with whatever you're doing with the containers and shut down your machine
3. Boot up again to find the containers restarted