### PR TITLE
installation: remove upper click bound

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ tests_require = [
 ]
 
 extras_require = {
-    "docs": ["Sphinx>=2.4",],
+    "docs": ["Sphinx>=4.2.0,<5",],
     "tests": tests_require,
 }
 
@@ -34,7 +34,7 @@ for reqs in extras_require.values():
 
 
 install_requires = [
-    "click>=7.0,<8.0",
+    "click>=7.0",
 ]
 
 packages = find_packages()


### PR DESCRIPTION
* The upper bound on click has the side-effect of only allowing Celery
  5.1.x to be installed as it's the only celery version compatible
  with click 7-8, while 5.2 is only compatible with click 8+.

