### PR TITLE
Make OpenSearch 2 the default search engine

### DIFF
--- a/docker_services_cli/__init__.py
+++ b/docker_services_cli/__init__.py
@@ -13,13 +13,13 @@ The specific version for the services can be set through environment variables
 
 .. code-block:: console
 
-    $ export OPENSEARCH_VERSION=1.3.4
+    $ export OPENSEARCH_VERSION=2.3.0
 
 It can also use the centrally managed (supported) major version:
 
 .. code-block:: console
 
-    $ export OPENSEARCH_VERSION=OS_1_LATEST
+    $ export OPENSEARCH_VERSION=OPENSEARCH_2_LATEST
 
 Then it simply needs to boot up the services. Note that if no version was
 exported in the environment, the CLI will use the default values set in

--- a/docker_services_cli/config.py
+++ b/docker_services_cli/config.py
@@ -39,9 +39,10 @@ ELASTICSEARCH = {
 
 # Opensearch
 OPENSEARCH = {
-    "OPENSEARCH_VERSION": "OPENSEARCH_1_LATEST",
+    "OPENSEARCH_VERSION": "OPENSEARCH_2_LATEST",
     "DEFAULT_VERSIONS": {
-        "OPENSEARCH_1_LATEST": "1.3.4",
+        "OPENSEARCH_1_LATEST": "1.3.5",
+        "OPENSEARCH_2_LATEST": "2.3.0",
     },
 }
 """Opensearch service configuration."""


### PR DESCRIPTION
Make OpenSearch 2.x the default search engine