### PR TITLE
add back Python 3.6

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,3 +1,5 @@
+name: Publish
+
 on:
   push:
     tags:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       matrix:
           python-version: [3.7, 3.8, 3.9]
-          requirements-level: [min, pypi]
+          requirements-level: [pypi]
     env:
       EXTRAS: tests
     steps:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2020 CERN.
+# Copyright (C) 2020-2023 CERN.
 # Copyright (C) 2022 Graz University of Technology.
 #
 # Docker-Services-CLI is free software; you can redistribute it and/or modify it
@@ -9,7 +9,7 @@
 [metadata]
 name = Docker-Services-CLI
 version = attr: docker_services_cli.__version__
-description = "Python module to ease the creation and management of external services."
+description = Python module to ease the creation and management of external services.
 long_description = file: README.rst, CHANGES.rst
 keywords = docker services cli
 license = MIT
@@ -23,19 +23,20 @@ classifiers =
 [options]
 include_package_data = True
 packages = find:
-python_requires = >=3.7
+python_requires = >=3.6
 zip_safe = False
 install_requires =
     click>=7.0
 
 [options.extras_require]
 tests =
-    pytest-black==0.3.9
     check-manifest>=0.42
-    pytest-cov>=2.10.1
-    pytest-isort>=1.2.0
-    pytest-pydocstyle>=2.2.0
-    pytest>=6,<7
+    pytest-black>=0.3.0
+    pytest-cov>=3.0.0
+    pytest-isort>=3.0.0
+    pytest-pydocstyle>=2.2.3
+    pytest-pycodestyle>=2.2.0
+    pytest>=6,<7.2.0
     sphinx>=4.5
 
 [options.entry_points]


### PR DESCRIPTION
- relax min version of Python to 3.6, given that some modules and services still needs it.