### PR TITLE
config: use other port for services

### DIFF
--- a/docker_services_cli/config.py
+++ b/docker_services_cli/config.py
@@ -63,7 +63,7 @@ POSTGRESQL = {
     },
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
         "db": {
-            "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
+            "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg2://invenio:invenio@localhost:5433/invenio"
         }
     },
 }
@@ -94,7 +94,7 @@ REDIS = {
         "REDIS_7_LATEST": "7",
     },
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
-        "mq": {"BROKER_URL": "redis://localhost:6379/0"},
+        "mq": {"BROKER_URL": "redis://localhost:6380/0"},
         "cache": {"CACHE_TYPE": "redis"},
     },
 }
@@ -104,7 +104,7 @@ RABBITMQ = {
     "RABBITMQ_VERSION": "RABBITMQ_3_LATEST",
     "DEFAULT_VERSIONS": {"RABBITMQ_3_LATEST": "3"},
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
-        "mq": {"BROKER_URL": "amqp://localhost:5672//"}
+        "mq": {"BROKER_URL": "amqp://localhost:5673//"}
     },
 }
 """RabbitMQ service configuration."""

--- a/docker_services_cli/docker-services.yml
+++ b/docker_services_cli/docker-services.yml
@@ -12,7 +12,7 @@ services:
     restart: "unless-stopped"
     read_only: true
     ports:
-      - "6379:6379"
+      - "6380:6379"
   mysql:
     image: mysql:${MYSQL_VERSION}
     restart: "unless-stopped"
@@ -31,7 +31,7 @@ services:
       - "POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}"
       - "POSTGRES_DB=${POSTGRESQL_DB}"
     ports:
-      - "5432:5432"
+      - "5433:5432"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ELASTICSEARCH_VERSION}
     restart: "unless-stopped"
@@ -45,8 +45,8 @@ services:
         hard: -1
     mem_limit: 2g
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "9201:9200"
+      - "9301:9300"
   opensearch:
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
     restart: "unless-stopped"
@@ -65,11 +65,11 @@ services:
         hard: 65536
     mem_limit: 2g
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "9201:9200"
+      - "9301:9300"
   rabbitmq:
     image: rabbitmq:${RABBITMQ_VERSION}-management
     restart: "unless-stopped"
     ports:
-      - "15672:15672"
-      - "5672:5672"
+      - "15673:15672"
+      - "5673:5672"

--- a/docker_services_cli/services.py
+++ b/docker_services_cli/services.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2020 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Docker-Services-CLI is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -39,7 +40,7 @@ def search_healthcheck(*args, **kwargs):
     verbose = kwargs["verbose"]
 
     return _run_healthcheck_command(
-        ["curl", "-f", "localhost:9200/_cluster/health?wait_for_status=green"], verbose
+        ["curl", "-f", "localhost:9201/_cluster/health?wait_for_status=green"], verbose
     )
 
 


### PR DESCRIPTION
* this change makes it possible to run tests at the same time as a the
  services exists for normal development. so it is not necessary to
  stop the development containers to run tests!
