### PR TITLE
Feature: s3 support

### DIFF
--- a/docker_services_cli/config.py
+++ b/docker_services_cli/config.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2024 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2025 CESNET z.s.p.o.
 #
 # Docker-Services-CLI is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -119,6 +120,25 @@ RABBITMQ = {
 }
 """RabbitMQ service configuration."""
 
+MINIO = {
+    "MINIO_VERSION": "MINIO_2025_LATEST",
+    # note: minio does not do semantic versioning, so we use the latest version
+    # the release at the time of writing this is RELEASE.2025-02-28T09-55-16Z
+    "DEFAULT_VERSIONS": {"MINIO_2025_LATEST": "latest"},
+    "CONTAINER_CONFIG_ENVIRONMENT_VARIABLES": {
+        "S3_ACCESS_KEY_ID": "invenio",
+        "S3_SECRET_ACCESS_KEY": "invenio8",
+    },
+    "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
+        "s3": {
+            "S3_ENDPOINT_URL": "http://localhost:9000",
+            "S3_ACCESS_KEY_ID": "invenio",
+            "S3_SECRET_ACCESS_KEY": "invenio8",
+        }
+    },
+}
+"""MINIO service configuration."""
+
 SERVICES = {
     "elasticsearch": ELASTICSEARCH,
     "opensearch": OPENSEARCH,
@@ -126,6 +146,7 @@ SERVICES = {
     "mysql": MYSQL,
     "redis": REDIS,
     "rabbitmq": RABBITMQ,
+    "minio": MINIO,
 }
 """List of services to configure."""
 
@@ -136,6 +157,7 @@ SERVICES_ALL_DEFAULT_VERSIONS = {
     **REDIS.get("DEFAULT_VERSIONS", {}),
     **MYSQL.get("DEFAULT_VERSIONS", {}),
     **RABBITMQ.get("DEFAULT_VERSIONS", {}),
+    **MINIO.get("DEFAULT_VERSIONS", {}),
 }
 """Services default latest versions."""
 
@@ -146,5 +168,6 @@ SERVICE_TYPES = {
         "redis",
     ],
     "mq": ["rabbitmq", "redis"],
+    "s3": ["minio"],
 }
 """Types of offered services."""

--- a/docker_services_cli/config.py
+++ b/docker_services_cli/config.py
@@ -127,12 +127,14 @@ MINIO = {
     "DEFAULT_VERSIONS": {"MINIO_2025_LATEST": "latest"},
     "CONTAINER_CONFIG_ENVIRONMENT_VARIABLES": {
         "S3_ACCESS_KEY_ID": "invenio",
+        # minio needs at least 8 characters for the secret
         "S3_SECRET_ACCESS_KEY": "invenio8",
     },
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
         "s3": {
             "S3_ENDPOINT_URL": "http://localhost:9000",
             "S3_ACCESS_KEY_ID": "invenio",
+            # minio needs at least 8 characters for the secret
             "S3_SECRET_ACCESS_KEY": "invenio8",
         }
     },

--- a/docker_services_cli/docker-services.yml
+++ b/docker_services_cli/docker-services.yml
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020-2022 CERN.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2025 CESNET z.s.p.o.
 #
 # Docker-Services-CLI is free software; you can redistribute it and/or modify it
 # under the terms of the MIT License; see LICENSE file for more details.
@@ -73,3 +74,17 @@ services:
     ports:
       - "15673:15672"
       - "5673:5672"
+  minio:
+    image: minio/minio:${MINIO_VERSION}
+    restart: "unless-stopped"
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY}
+    entrypoint: >
+      /bin/sh -c "
+      mkdir -p /data/default;
+      /usr/bin/docker-entrypoint.sh server /data --console-address :9001
+      "
+    ports:
+      - "9000:9000"
+      - "9001:9001"

--- a/docker_services_cli/env.py
+++ b/docker_services_cli/env.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2025 CESNET z.s.p.o.
 #
 # Docker-Services-CLI is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -73,6 +74,10 @@ def _load_or_set_env(services_version, default_version):
         os.environ[services_version] = version_from_env
 
     elif major_version_from_env and _is_version(major_version_from_env):
+        os.environ[services_version] = major_version_from_env
+
+    elif major_version_from_env == "latest":
+        # for example for minio, where we do not have a semantic version
         os.environ[services_version] = major_version_from_env
 
     else:

--- a/docker_services_cli/services.py
+++ b/docker_services_cli/services.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2020 CERN.
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2025 CESNET z.s.p.o.
 #
 # Docker-Services-CLI is free software; you can redistribute it and/or modify
 # it under the terms of the MIT License; see LICENSE file for more details.
@@ -14,7 +15,7 @@ from subprocess import PIPE, Popen, check_call
 
 import click
 
-from .config import DOCKER_SERVICES_FILEPATH, MYSQL, POSTGRESQL, SERVICE_TYPES
+from .config import DOCKER_SERVICES_FILEPATH, MYSQL, SERVICE_TYPES
 
 
 def _run_healthcheck_command(command, verbose=False):
@@ -136,6 +137,14 @@ def redis_healthcheck(*args, **kwargs):
     )
 
 
+def minio_healthcheck(*args, **kwargs):
+    verbose = kwargs["verbose"]
+
+    return _run_healthcheck_command(
+        ["curl", "-f", "http://localhost:9000/minio/health/live"], verbose
+    )
+
+
 HEALTHCHECKS = {
     "elasticsearch": search_healthcheck,
     "opensearch": search_healthcheck,
@@ -143,6 +152,7 @@ HEALTHCHECKS = {
     "mysql": mysql_healthcheck,
     "rabbitmq": rabbitmq_healthcheck,
     "redis": redis_healthcheck,
+    "minio": minio_healthcheck,
 }
 """Health check functions module path, as string."""
 


### PR DESCRIPTION
### Description

This PR adds support for MinIO S3 implementation into docker-services-cli.
A new service was added to docker compose which at first creates a bucket
(inspired by https://github.com/minio/minio/issues/4769) and then starts the server.

The motivation is the ability to run tests with S3 in invenio-records-resources/invenio-s3
and use the same framework to start/stop this service.

#### Usage
```
❯ docker-services-cli up --s3 minio --env
[+] Running 2/2
 ✔ Network docker_services_cli_default    Created                                                                                                                                                                                   0.1s 
 ✔ Container docker_services_cli-minio-1  Started                                                                                                                                                                                   0.3s 
minio not ready at 1 retries, waiting 2s
minio up and running!
Services up!

export S3_ENDPOINT_URL=http://localhost:9000
export S3_ACCESS_KEY_ID=invenio
export S3_SECRET_ACCESS_KEY=invenio8
```

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
