### PR TITLE
Revert "config: use other port for services"

### DIFF
--- a/docker_services_cli/config.py
+++ b/docker_services_cli/config.py
@@ -74,7 +74,7 @@ POSTGRESQL = {
     },
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
         "db": {
-            "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg2://invenio:invenio@localhost:5433/invenio"
+            "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg2://invenio:invenio@localhost:5432/invenio"
         }
     },
 }
@@ -105,7 +105,7 @@ REDIS = {
         "REDIS_7_LATEST": "7",
     },
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
-        "mq": {"BROKER_URL": "redis://localhost:6380/0"},
+        "mq": {"BROKER_URL": "redis://localhost:6379/0"},
         "cache": {"CACHE_TYPE": "redis"},
     },
 }
@@ -115,7 +115,7 @@ RABBITMQ = {
     "RABBITMQ_VERSION": "RABBITMQ_3_LATEST",
     "DEFAULT_VERSIONS": {"RABBITMQ_3_LATEST": "3"},
     "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
-        "mq": {"BROKER_URL": "amqp://localhost:5673//"}
+        "mq": {"BROKER_URL": "amqp://localhost:5672//"}
     },
 }
 """RabbitMQ service configuration."""

--- a/docker_services_cli/docker-services.yml
+++ b/docker_services_cli/docker-services.yml
@@ -13,7 +13,7 @@ services:
     restart: "unless-stopped"
     read_only: true
     ports:
-      - "6380:6379"
+      - "6379:6379"
   mysql:
     image: mysql:${MYSQL_VERSION}
     restart: "unless-stopped"
@@ -32,7 +32,7 @@ services:
       - "POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}"
       - "POSTGRES_DB=${POSTGRESQL_DB}"
     ports:
-      - "5433:5432"
+      - "5432:5432"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ELASTICSEARCH_VERSION}
     restart: "unless-stopped"
@@ -46,8 +46,8 @@ services:
         hard: -1
     mem_limit: 2g
     ports:
-      - "9201:9200"
-      - "9301:9300"
+      - "9200:9200"
+      - "9300:9300"
   opensearch:
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
     restart: "unless-stopped"
@@ -66,14 +66,14 @@ services:
         hard: 65536
     mem_limit: 2g
     ports:
-      - "9201:9200"
-      - "9301:9300"
+      - "9200:9200"
+      - "9300:9300"
   rabbitmq:
     image: rabbitmq:${RABBITMQ_VERSION}-management
     restart: "unless-stopped"
     ports:
-      - "15673:15672"
-      - "5673:5672"
+      - "15672:15672"
+      - "5672:5672"
   minio:
     image: minio/minio:${MINIO_VERSION}
     restart: "unless-stopped"

--- a/docker_services_cli/services.py
+++ b/docker_services_cli/services.py
@@ -41,7 +41,7 @@ def search_healthcheck(*args, **kwargs):
     verbose = kwargs["verbose"]
 
     return _run_healthcheck_command(
-        ["curl", "-f", "localhost:9201/_cluster/health?wait_for_status=green"], verbose
+        ["curl", "-f", "localhost:9200/_cluster/health?wait_for_status=green"], verbose
     )
 
 


### PR DESCRIPTION
This reverts commit d920a3d4483926efc629ca9ed23501ed9f9f1934.

- We are planning to first make sure that other modules take into
  account all the exposed environment variables, since right now it just
  happens by chance that default config variables matched the default
  localhost + port combinations that the underlying services anyways
  expose.
