### PR TITLE
search config env

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version v0.12.0 (released 2025-04-11)
+
+- config: export `SEARCH_HOSTS` environment for OpenSearch/ElasticSearch
+
 Version v0.11.1 (released 2025-04-11)
 
 - Fix incomplete revert of port config change

--- a/docker_services_cli/__init__.py
+++ b/docker_services_cli/__init__.py
@@ -37,6 +37,6 @@ And turn them of once they are not needed anymore:
     $ docker-services-cli down
 """
 
-__version__ = "0.11.1"
+__version__ = "0.12.0"
 
 __all__ = ("__version__",)

--- a/docker_services_cli/config.py
+++ b/docker_services_cli/config.py
@@ -36,6 +36,11 @@ ELASTICSEARCH = {
     "DEFAULT_VERSIONS": {
         "ELASTICSEARCH_7_LATEST": "7.10.2",  # the last of the OSS versions (https://github.com/elastic/elasticsearch/issues/58303)
     },
+    "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
+        "search": {
+            "SEARCH_HOSTS": "\"[{'host': 'localhost', 'port': 9200}]\"",
+        }
+    },
 }
 """Elasticsearch service configuration."""
 
@@ -45,6 +50,11 @@ OPENSEARCH = {
     "DEFAULT_VERSIONS": {
         "OPENSEARCH_1_LATEST": "1.3.18",
         "OPENSEARCH_2_LATEST": "2.16.0",
+    },
+    "CONTAINER_CONNECTION_ENVIRONMENT_VARIABLES": {
+        "search": {
+            "SEARCH_HOSTS": "\"[{'host': 'localhost', 'port': 9200}]\"",
+        }
     },
 }
 """Opensearch service configuration."""


### PR DESCRIPTION
- **config: export `SEARCH_HOSTS` environment for OpenSearch/ElasticSearch**
  

- **📦 release: v0.12.0**
  