### PR TITLE
fix: bind `127.0.0.1` by default for service ports

### DIFF
--- a/docker_services_cli/docker-services.yml
+++ b/docker_services_cli/docker-services.yml
@@ -13,7 +13,7 @@ services:
     restart: "unless-stopped"
     read_only: true
     ports:
-      - "6379:6379"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:6379:6379"
   mysql:
     image: mysql:${MYSQL_VERSION}
     restart: "unless-stopped"
@@ -23,7 +23,7 @@ services:
       - "MYSQL_USER=${MYSQL_USER}"
       - "MYSQL_PASSWORD=${MYSQL_PASSWORD}"
     ports:
-      - "3306:3306"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:3306:3306"
   postgresql:
     image: postgres:${POSTGRESQL_VERSION}
     restart: "unless-stopped"
@@ -32,7 +32,7 @@ services:
       - "POSTGRES_PASSWORD=${POSTGRESQL_PASSWORD}"
       - "POSTGRES_DB=${POSTGRESQL_DB}"
     ports:
-      - "5432:5432"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5432:5432"
   elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:${ELASTICSEARCH_VERSION}
     restart: "unless-stopped"
@@ -46,8 +46,8 @@ services:
         hard: -1
     mem_limit: 2g
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9200:9200"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9300:9300"
   opensearch:
     image: opensearchproject/opensearch:${OPENSEARCH_VERSION}
     restart: "unless-stopped"
@@ -66,14 +66,14 @@ services:
         hard: 65536
     mem_limit: 2g
     ports:
-      - "9200:9200"
-      - "9300:9300"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9200:9200"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9300:9300"
   rabbitmq:
     image: rabbitmq:${RABBITMQ_VERSION}-management
     restart: "unless-stopped"
     ports:
-      - "15672:15672"
-      - "5672:5672"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:15672:15672"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:5672:5672"
   minio:
     image: minio/minio:${MINIO_VERSION}
     restart: "unless-stopped"
@@ -86,5 +86,5 @@ services:
       /usr/bin/docker-entrypoint.sh server /data --console-address :9001
       "
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9000:9000"
+      - "${DOCKER_SERVICES_IP_BIND:-127.0.0.1}:9001:9001"


### PR DESCRIPTION
* Binds `127.0.0.1` as the host IP for all mapped service ports.
* Allows overriding the host IP using the `DOCKER_SERVICES_IP_BIND`
  environment variable.
